### PR TITLE
Add Docker development workflow and update resume

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+src/_site
+src/.jekyll-cache
+.git
+.github
+.claude
+.ruby-lsp
+*.md
+Makefile
+Dockerfile
+.dockerignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,27 +8,25 @@ Personal website for Chris Van Law (chrisvanlaw.com) built with Jekyll 4.2 and d
 
 ## Development Commands
 
+This project uses Docker to avoid local Ruby version management issues.
+
 Using Makefile (run from repository root):
 
 ```bash
-make help      # Show available commands
-make install   # Install dependencies
-make serve     # Run local development server (auto-rebuilds on changes)
-make build     # Build site (output to src/_site/)
-make drafts    # Run server with drafts visible
-make clean     # Clean generated files
+make help         # Show available commands
+make serve        # Run local development server with live reload (http://localhost:4000)
+make build        # Build the site (output to src/_site/)
+make drafts       # Run server with drafts visible
+make clean        # Clean generated files
+make install      # Install/update dependencies in container
+make shell        # Open bash shell in container
+make docker-down  # Stop and remove containers
 ```
 
-Or use bundle commands directly from the `src/` directory:
-
-```bash
-bundle install
-bundle exec jekyll serve
-bundle exec jekyll build
-bundle exec jekyll serve --drafts
-```
-
-Note: Jekyll config changes require server restart.
+Note:
+- First run will build the Docker image (Ruby 3.1 with bundler 2.3.12)
+- Jekyll config changes require server restart (Ctrl+C and `make serve` again)
+- Site runs at http://localhost:4000 with live reload enabled
 
 ## Architecture
 
@@ -57,7 +55,9 @@ Requires AWS credentials and config in GitHub secrets:
 - `BUCKET_NAME`
 - `DISTRIBUTION_ID`
 
-## Ruby Environment
-- Requires Ruby 3.1 (per CI workflow)
-- System may have Ruby 2.6, use `ruby/setup-ruby` or rbenv/rvm for correct version
-- Gemfile.lock specifies bundler 2.3.12
+## Docker Setup
+- Uses Ruby 3.1 base image
+- Bundler 2.3.12 installed
+- Volume mounts `src/` directory for live editing
+- Bundle cache persisted in Docker volume for faster rebuilds
+- No local Ruby installation required

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Personal website for Chris Van Law (chrisvanlaw.com) built with Jekyll 4.2 and deployed to AWS S3 with CloudFront distribution.
+
+## Development Commands
+
+All commands run from the `src/` directory:
+
+```bash
+# Install dependencies
+bundle install
+
+# Local development server (auto-rebuilds on changes)
+bundle exec jekyll serve
+
+# Build site (output to _site/)
+bundle exec jekyll build
+
+# Build with drafts visible
+bundle exec jekyll serve --drafts
+```
+
+Note: Jekyll config changes require server restart.
+
+## Architecture
+
+### Structure
+- `src/` - Jekyll site root
+  - `_config.yml` - Site configuration (title, email, theme)
+  - `index.markdown` - Homepage with resume/CV content
+  - `_drafts/` - Unpublished posts (visible with `--drafts` flag)
+  - `_site/` - Generated static site (gitignored)
+
+### Theme & Plugins
+- Uses Minima theme (2.5)
+- Jekyll Feed plugin for RSS
+- No custom layouts or includes (theme defaults)
+
+### Deployment
+GitHub Actions workflow (`.github/workflows/website.yml`):
+1. Builds on every push/PR
+2. Creates semantic version tags on main branch
+3. Deploys to S3 bucket on main branch pushes
+4. Invalidates CloudFront cache for index.html
+
+Requires AWS credentials and config in GitHub secrets:
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `BUCKET_NAME`
+- `DISTRIBUTION_ID`
+
+## Ruby Environment
+- Requires Ruby 3.1 (per CI workflow)
+- System may have Ruby 2.6, use `ruby/setup-ruby` or rbenv/rvm for correct version
+- Gemfile.lock specifies bundler 2.3.12

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,19 +8,23 @@ Personal website for Chris Van Law (chrisvanlaw.com) built with Jekyll 4.2 and d
 
 ## Development Commands
 
-All commands run from the `src/` directory:
+Using Makefile (run from repository root):
 
 ```bash
-# Install dependencies
+make help      # Show available commands
+make install   # Install dependencies
+make serve     # Run local development server (auto-rebuilds on changes)
+make build     # Build site (output to src/_site/)
+make drafts    # Run server with drafts visible
+make clean     # Clean generated files
+```
+
+Or use bundle commands directly from the `src/` directory:
+
+```bash
 bundle install
-
-# Local development server (auto-rebuilds on changes)
 bundle exec jekyll serve
-
-# Build site (output to _site/)
 bundle exec jekyll build
-
-# Build with drafts visible
 bundle exec jekyll serve --drafts
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ruby:3.1
+
+WORKDIR /site
+
+# Install bundler
+RUN gem install bundler:2.3.12
+
+# Copy Gemfile first for better caching
+COPY src/Gemfile src/Gemfile.lock ./
+
+# Install dependencies
+RUN bundle install
+
+# Copy the rest of the site
+COPY src/ ./
+
+# Expose Jekyll server port
+EXPOSE 4000
+
+# Default command
+CMD ["bundle", "exec", "jekyll", "serve", "--host", "0.0.0.0"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: serve build install clean drafts help
+
+JEKYLL_DIR = src
+
+help: ## Show this help message
+	@echo 'Usage: make [target]'
+	@echo ''
+	@echo 'Available targets:'
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+install: ## Install dependencies
+	cd $(JEKYLL_DIR) && bundle install
+
+serve: ## Run local development server
+	cd $(JEKYLL_DIR) && bundle exec jekyll serve
+
+build: ## Build the site
+	cd $(JEKYLL_DIR) && bundle exec jekyll build
+
+drafts: ## Run server with drafts visible
+	cd $(JEKYLL_DIR) && bundle exec jekyll serve --drafts
+
+clean: ## Clean generated files
+	cd $(JEKYLL_DIR) && bundle exec jekyll clean

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ help: ## Show this help message
 install: ## Install dependencies
 	cd $(JEKYLL_DIR) && bundle install
 
-serve: ## Run local development server
-	cd $(JEKYLL_DIR) && bundle exec jekyll serve
-
-build: ## Build the site
+build: install ## Build the site
 	cd $(JEKYLL_DIR) && bundle exec jekyll build
 
-drafts: ## Run server with drafts visible
+serve: install build ## Run local development server
+	cd $(JEKYLL_DIR) && bundle exec jekyll serve
+
+drafts: install ## Run server with drafts visible
 	cd $(JEKYLL_DIR) && bundle exec jekyll serve --drafts
 
 clean: ## Clean generated files

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-.PHONY: serve build install clean drafts help
+.PHONY: serve build install clean drafts help docker-build docker-down shell
 
 JEKYLL_DIR = src
+DOCKER_RUN = docker compose run --rm jekyll
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -8,17 +9,26 @@ help: ## Show this help message
 	@echo 'Available targets:'
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-install: ## Install dependencies
-	cd $(JEKYLL_DIR) && bundle install
+docker-build: ## Build Docker image
+	docker compose build
 
-build: install ## Build the site
-	cd $(JEKYLL_DIR) && bundle exec jekyll build
+install: docker-build ## Install dependencies
+	$(DOCKER_RUN) bundle install
 
-serve: install build ## Run local development server
-	cd $(JEKYLL_DIR) && bundle exec jekyll serve
+build: ## Build the site
+	$(DOCKER_RUN) bundle exec jekyll build
 
-drafts: install ## Run server with drafts visible
-	cd $(JEKYLL_DIR) && bundle exec jekyll serve --drafts
+serve: docker-build ## Run local development server with live reload
+	docker compose up
+
+drafts: docker-build ## Run server with drafts visible
+	$(DOCKER_RUN) bundle exec jekyll serve --host 0.0.0.0 --drafts
 
 clean: ## Clean generated files
-	cd $(JEKYLL_DIR) && bundle exec jekyll clean
+	$(DOCKER_RUN) bundle exec jekyll clean
+
+docker-down: ## Stop and remove containers
+	docker compose down
+
+shell: docker-build ## Open shell in container
+	$(DOCKER_RUN) /bin/bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   jekyll:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  jekyll:
+    build: .
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./src:/site
+      - bundle_cache:/usr/local/bundle
+    environment:
+      - JEKYLL_ENV=development
+    command: bundle exec jekyll serve --host 0.0.0.0 --livereload
+
+volumes:
+  bundle_cache:

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     webrick (1.7.0)
 
 PLATFORMS
+  aarch64-linux
   universal-darwin-21
   x86_64-linux
 

--- a/src/index.markdown
+++ b/src/index.markdown
@@ -5,14 +5,28 @@
 layout: home
 ---
 
-# Objective
+# About
 
-Highly motivated software and devops engineer seeking a challenging senior individual contributor position, where I can utilize my expertise in cloud-native and microservice architectures and extensive experience in delivering quality solutions to Fortune 100 customers.
+Platform Engineer focused on cloud-native infrastructure, developer experience, and AI-powered tooling. Building systems that are reliable, observable, and enable teams to move fast. Experienced in Kubernetes cluster management, infrastructure automation with Terraform, and establishing observability practices using Datadog. Passionate about reducing operational burden through better abstractions and empowering engineers with self-service platforms.
 
 # Experience
+### Fanatics Betting & Gaming
+
+Online sports betting and iGaming platform.
+
+#### Staff Engineer, Platform Engineering | *October 2023 - Present*
+
+Lead strategic platform infrastructure initiatives supporting sports betting operations across multiple EKS clusters.
+
+* Led infrastructure buildout for Fanatics Markets (FMX) trading platform, provisioning AWS accounts, EKS clusters, and observability systems
+* Rewrote RDS snapshot system from Python to Go, reducing memory usage from multiple gigabytes to under 100MB
+* Took ownership of Datadog vendor relationship, coordinating product meetings and implementing cost transparency reporting
+* Implemented AI-powered platform tooling using AWS Bedrock for automated PR review and intelligent support request routing
+* Advanced to AWS re:Invent semi-finals in Fanatics AI League competition, developing a responsible gaming AI assistant
+
 ### rearc
 A boutique cloud engineering and devops consulting company.
-#### Lead Cloud Engineer | *August 2021 - Present*
+#### Lead Cloud Engineer | *August 2021 - October 2023*
 Lead customer engagements designing and implementing cloud-native and microservice architectures. Throughout multiple customer engagements:
 
 * Designed and delivered an end-to-end SaaS authentication and authorization system using OAuth 2.0 and OIDC. Delivered user migration plan and tooling to allow the customer to migrate users with minimal end-user impact.
@@ -99,6 +113,7 @@ Assist QA team in performing test cases and recording/reporting their results to
 * SQL
 * TypeScript
 * Python
+* Go
 * HTML
 * JavaScript
 * CSS
@@ -118,15 +133,18 @@ Assist QA team in performing test cases and recording/reporting their results to
     * Solutions Architect Associate
 * Azure
 
-### Tools 
+### Tools
 
 * AWS
+    * Bedrock
 * Azure
 * Kubernetes
     * EKS
     * AKS
+    * Karpenter
 * Helm
 * Terraform
+* Datadog
 * CI/CD
     * Azure DevOps
     * GitHub Actions


### PR DESCRIPTION
## Summary

- Add Docker-based development environment to avoid local Ruby version management
- Add CLAUDE.md with project development guide
- Add Makefile for common development tasks
- Update resume with current role at Fanatics Betting & Gaming
- Refresh About section to reflect current interests as Platform Engineer

## Changes

### Development Environment
- Dockerfile with Ruby 3.1 and bundler 2.3.12
- docker-compose.yml for local development server
- Makefile with commands: `make serve`, `make build`, `make drafts`, etc.
- CLAUDE.md documenting project structure and development workflow

### Resume Updates
- Add Fanatics Betting & Gaming (Staff Engineer, Platform Engineering, Oct 2023 - Present)
- Replace job-seeking "Objective" with interest-focused "About" section
- Update rearc end date to October 2023
- Add Go, Datadog, AWS Bedrock, Karpenter to skills

## Test plan

- [x] `make serve` runs local development server successfully
- [x] Site renders correctly at http://localhost:4000
- [x] Resume displays new Fanatics role and updated About section