### PR TITLE
chore(deps): update GitHub Actions to current versions

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,10 +8,10 @@ on:
 jobs:
   build:
     name: 'Build'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: '100'
       - name: Bump version and push tag
@@ -40,7 +40,7 @@ jobs:
   deploy:
     name: 'Deploy'
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.ref_name == 'main'
     steps:
       - name: Download Build Artifact

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -33,7 +33,7 @@ jobs:
           bundle exec jekyll build
       - name: Upload Build Artifact
         if: github.ref_name == 'main'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build_assets
           path: src/_site
@@ -44,7 +44,7 @@ jobs:
     if: github.ref_name == 'main'
     steps:
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build_assets
           path: build_assets


### PR DESCRIPTION
## Summary
- Update `actions/upload-artifact` from v3 to v4
- Update `actions/download-artifact` from v3 to v4
- Update `actions/checkout` from v3 to v4
- Update runners from `ubuntu-20.04` to `ubuntu-latest`

## Why
- **Artifact actions v3**: Deprecated, will stop working January 30, 2025. v3 and v4 are not cross-compatible.
- **Checkout v3**: Uses Node 16 which is EOL
- **ubuntu-20.04**: Fully deprecated since April 15, 2025. Jobs using it get stuck in queue.

Supersedes #18 which only updated download-artifact.

## References
- [Deprecation notice: v3 of the artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
- [Ubuntu 20 runner deprecation](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/)