### PR TITLE
fix: cloudfront function test events and full-path cache invalidation

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: build_assets
         run: |
           aws s3 sync . s3://$BUCKET_NAME --metadata-directive 'REPLACE'
-          aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths /index.html
+          aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths "/*"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/infra/cloudfront-functions/test-events/no-extension.json
+++ b/infra/cloudfront-functions/test-events/no-extension.json
@@ -1,0 +1,12 @@
+{
+    "version": "1.0",
+    "context": { "eventType": "viewer-request" },
+    "viewer": { "ip": "1.2.3.4" },
+    "request": {
+        "method": "GET",
+        "uri": "/resume",
+        "headers": {},
+        "cookies": {},
+        "querystring": {}
+    }
+}

--- a/infra/cloudfront-functions/test-events/root.json
+++ b/infra/cloudfront-functions/test-events/root.json
@@ -1,0 +1,12 @@
+{
+    "version": "1.0",
+    "context": { "eventType": "viewer-request" },
+    "viewer": { "ip": "1.2.3.4" },
+    "request": {
+        "method": "GET",
+        "uri": "/",
+        "headers": {},
+        "cookies": {},
+        "querystring": {}
+    }
+}

--- a/infra/cloudfront-functions/test-events/static-asset.json
+++ b/infra/cloudfront-functions/test-events/static-asset.json
@@ -1,0 +1,12 @@
+{
+    "version": "1.0",
+    "context": { "eventType": "viewer-request" },
+    "viewer": { "ip": "1.2.3.4" },
+    "request": {
+        "method": "GET",
+        "uri": "/assets/css/style.css",
+        "headers": {},
+        "cookies": {},
+        "querystring": {}
+    }
+}

--- a/infra/cloudfront-functions/test-events/trailing-slash.json
+++ b/infra/cloudfront-functions/test-events/trailing-slash.json
@@ -1,0 +1,12 @@
+{
+    "version": "1.0",
+    "context": { "eventType": "viewer-request" },
+    "viewer": { "ip": "1.2.3.4" },
+    "request": {
+        "method": "GET",
+        "uri": "/resume/",
+        "headers": {},
+        "cookies": {},
+        "querystring": {}
+    }
+}


### PR DESCRIPTION
## Summary

- Adds test event JSON files for the `append-index-html` CloudFront Function under `infra/cloudfront-functions/test-events/` (trailing slash, no extension, static asset passthrough, root path)
- Fixes CI/CD cache invalidation: changes `--paths /index.html` to `--paths "/*"` so all pages get fresh cache on every deploy, not just the home page

## Context

The CloudFront Function itself was deployed via the infrastructure repo (PR #42). These changes are the website-repo side: test fixtures for the function and the CI/CD fix that ensures future deploys properly bust the cache for all pages including `/resume/`.